### PR TITLE
Fix JWT subject type to ensure tokens decode

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -14,7 +14,11 @@ def verify_pw(raw: str, hashed: str) -> bool: return pwd.verify(raw, hashed)
 
 def create_token(user_id: int) -> str:
     exp = dt.datetime.utcnow() + dt.timedelta(days=7)
-    return jwt.encode({"sub": user_id, "exp": exp}, SECRET, ALGO)
+    # The JWT spec expects the "sub" (subject) claim to be a string,
+    # but our user IDs are integers. python-jose enforces this and will
+    # raise a "Subject must be a string" error if we pass an int. Cast
+    # the ID to str so tokens can be decoded successfully.
+    return jwt.encode({"sub": str(user_id), "exp": exp}, SECRET, ALGO)
 
 def get_current_user(token: str | None = Cookie(default=None)):
     if not token:

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,9 @@
 from sqlmodel import SQLModel, Field
 
+
 class User(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
-    email: str     = Field(index=True, unique=True, nullable=False)
-    hashed_password: str
+    email: str = Field(index=True, unique=True, nullable=False)
+    # Explicitly mark the password column as non-nullable and add a
+    # trailing newline to keep tools and the shell happy.
+    hashed_password: str = Field(nullable=False)


### PR DESCRIPTION
## Summary
- cast user ID to string when generating JWT so `get_current_user` can decode tokens without errors
- explicitly mark `hashed_password` as non-nullable to clean up model definition

## Testing
- `pytest -q`
- `python -m py_compile app/auth.py app/models.py`


------
https://chatgpt.com/codex/tasks/task_e_6892759b8cfc8330bcc343936fad2bb1