### PR TITLE
Separate home and generate pages; add gallery and auth logout

### DIFF
--- a/app/templates/_partials/nav.html
+++ b/app/templates/_partials/nav.html
@@ -6,8 +6,9 @@
     </a>
 
     <div class="flex items-center gap-4">
+      <a href="/gallery" class="hover:underline">Gallery</a>
       {% if user %}
-        <a href="/dashboard" class="hover:underline">Dashboard</a>
+        <a href="/generate" class="hover:underline">Generate</a>
         <form action="/logout" method="post">
           <button class="text-red-600 hover:underline">Logout</button>
         </form>

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Gallery – Draw → Photo{% endblock %}
+{% block content %}
+  <h1 class="text-3xl font-bold mb-6 text-center">Gallery</h1>
+  <p class="text-center text-gray-600">Coming soon: a showcase of generated images.</p>
+{% endblock %}

--- a/app/templates/generate.html
+++ b/app/templates/generate.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Generate – Draw → Photo{% endblock %}
+{% block content %}
+  <section class="flex items-center justify-center">
+    <div class="card w-full max-w-md text-center">
+      <h1 class="text-3xl font-bold mb-4">Generate a Photo</h1>
+      <form action="/generate" method="post" enctype="multipart/form-data" class="space-y-4">
+        <input type="file" name="file" accept="image/png, image/jpeg"
+               class="file:mr-4 file:rounded-md file:border-0 file:bg-indigo-600 file:text-white file:px-4 file:py-2 hover:file:bg-indigo-700">
+        <button class="btn-primary">Generate</button>
+      </form>
+    </div>
+  </section>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,25 +1,11 @@
 {% extends "base.html" %}
 {% block title %}Home – Draw → Photo{% endblock %}
 {% block content %}
-  {% if user %}
-    <section class="flex items-center justify-center">
-      <div class="card w-full max-w-md text-center">
-        <h1 class="text-3xl font-bold mb-4">Generate a Photo</h1>
-        <form action="/generate" method="post" enctype="multipart/form-data" class="space-y-4">
-          <input type="file" name="file" accept="image/png, image/jpeg"
-                 class="file:mr-4 file:rounded-md file:border-0 file:bg-indigo-600 file:text-white file:px-4 file:py-2
-                        hover:file:bg-indigo-700">
-          <button class="btn-primary">Generate</button>
-        </form>
-      </div>
-    </section>
-  {% else %}
-    <section class="flex items-center justify-center h-[60vh]">
-      <div class="card text-center">
-        <h1 class="text-4xl font-bold mb-4">Draw &rarr; Photo</h1>
-        <p class="mb-6">Turn your sketches into stunning photos using AI.</p>
-        <a href="/login" class="btn-primary">Get Started</a>
-      </div>
-    </section>
-  {% endif %}
+  <section class="flex items-center justify-center h-[60vh]">
+    <div class="card text-center">
+      <h1 class="text-4xl font-bold mb-4">Draw &rarr; Photo</h1>
+      <p class="mb-6">Turn your sketches into stunning photos using AI.</p>
+      <a href="/login" class="btn-primary">Get Started</a>
+    </div>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- split home and generation pages so landing is separate
- require authentication for generation and add logout route
- add simple gallery page and navigation links

## Testing
- `pytest`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689279a909588330930db26073b3c812