### PR TITLE
Improve landing page styling and routing

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,18 +1,17 @@
 :root {
-  --primary: #1e3a8a;
-  --secondary: #3b82f6;
-  --accent: #60a5fa;
+  --primary: #ffecd2;
+  --secondary: #fcb69f;
+  --accent: #f59e0b;
 }
 
 body {
   background: linear-gradient(135deg, var(--primary), var(--secondary));
   color: #1f2937;
-  font-family: 'Helvetica Neue', Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 .card {
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(10px);
+  background: #fff8f0;
   padding: 2rem;
   border-radius: 1rem;
   box-shadow: 0 10px 15px rgba(0,0,0,0.1);
@@ -33,7 +32,7 @@ body {
 }
 
 .link {
-  color: var(--primary);
+  color: var(--accent);
 }
 .link:hover {
   text-decoration: underline;

--- a/app/templates/_partials/flash.html
+++ b/app/templates/_partials/flash.html
@@ -1,7 +1,10 @@
 {% if messages %}
-  <div id="flash-messages" class="fixed top-4 right-4 space-y-2 z-50">
+  <div id="flash-messages" class="mx-auto mb-4 max-w-md space-y-2">
     {% for m in messages %}
-      <div class="flash-msg border-l-4 px-4 py-2 {% if m.category=='error' %}border-blue-700 bg-blue-100{% else %}border-blue-500 bg-blue-50{% endif %}">
+      <div
+        class="flash-msg px-4 py-2 text-center rounded shadow
+               {% if m.category=='error' %}bg-red-100 text-red-800{% else %}bg-green-100 text-green-800{% endif %}"
+      >
         {{ m.text }}
       </div>
     {% endfor %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -8,7 +8,12 @@
   <!-- Tailwind (no build step) -->
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
 
-  <!-- If you want custom styles -->
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+
+  <!-- Custom styles -->
   <link rel="stylesheet" href="{{ url_for('static', path='css/main.css') }}">
 </head>
 <body class="min-h-screen flex flex-col">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,7 +5,7 @@
     <div class="card text-center">
       <h1 class="text-4xl font-bold mb-4">Draw &rarr; Photo</h1>
       <p class="mb-6">Turn your sketches into stunning photos using AI.</p>
-      <a href="/login" class="btn-primary">Get Started</a>
+      <a href="{{ '/generate' if user else '/login' }}" class="btn-primary">Get Started</a>
     </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- brighten site theme with cream gradient, solid card background, and Inter font
- route landing page "Get Started" to generator when logged in
- center flash notifications below header for better visibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689285955a2c8330bb41b7ac731a869d