### PR TITLE
Replace branding with CrayonAI and animate background

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ from app.ai_client import turn_sketch_into_photo
 BASE = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE / "templates"))
 templates.env.globals["now"] = datetime.utcnow
-app = FastAPI(title="Draw → Photo")
+app = FastAPI(title="CrayonAI")
 app.mount("/static", StaticFiles(directory=BASE / "static"), name="static")
 
 # ── DB setup (SQLite for now) ─────────────────────────────

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -5,9 +5,17 @@
 }
 
 body {
-  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  background: linear-gradient(-45deg, var(--primary), var(--secondary), var(--accent), #a78bfa);
+  background-size: 400% 400%;
+  animation: gradient 15s ease infinite;
   color: #1f2937;
   font-family: 'Inter', sans-serif;
+}
+
+@keyframes gradient {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
 .card {

--- a/app/templates/_partials/nav.html
+++ b/app/templates/_partials/nav.html
@@ -1,9 +1,6 @@
 <nav class="bg-white shadow-sm">
   <div class="container mx-auto px-4 py-3 flex items-center justify-between">
-    <a href="/" class="flex items-center gap-2 font-semibold">
-      <img src="{{ url_for('static', path='img/logo.svg') }}" alt="logo" class="h-8">
-      Draw → Photo
-    </a>
+    <a href="/" class="font-semibold text-xl">CrayonAI</a>
 
     <div class="flex items-center gap-4">
       <a href="/gallery" class="hover:underline">Gallery</a>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_partials/form_macros.html" import input %}
-{% block title %}Login – Draw → Photo{% endblock %}
+{% block title %}Login – CrayonAI{% endblock %}
 {% block content %}
   <section class="flex items-center justify-center h-[60vh]">
     <div class="card w-full max-w-sm">

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_partials/form_macros.html" import input %}
-{% block title %}Sign Up – Draw → Photo{% endblock %}
+{% block title %}Sign Up – CrayonAI{% endblock %}
 {% block content %}
   <section class="flex items-center justify-center h-[60vh]">
     <div class="card w-full max-w-sm">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{% block title %}Draw → Photo{% endblock %}</title>
+  <title>{% block title %}CrayonAI{% endblock %}</title>
 
   <!-- Tailwind (no build step) -->
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
@@ -26,7 +26,7 @@
   </main>
 
   <footer class="border-t py-4 text-center text-sm text-gray-500">
-    &copy; {{ now().year }} Draw → Photo
+    &copy; {{ now().year }} CrayonAI
   </footer>
 </body>
 </html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Dashboard – Draw → Photo{% endblock %}
+{% block title %}Dashboard – CrayonAI{% endblock %}
 {% block content %}
   <h1 class="text-3xl font-bold mb-6">Your recent generations</h1>
   <p class="text-gray-600">Coming soon: history, share links, etc.</p>

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Gallery – Draw → Photo{% endblock %}
+{% block title %}Gallery – CrayonAI{% endblock %}
 {% block content %}
   <h1 class="text-3xl font-bold mb-6 text-center">Gallery</h1>
   <p class="text-center text-gray-600">Coming soon: a showcase of generated images.</p>

--- a/app/templates/generate.html
+++ b/app/templates/generate.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Generate – Draw → Photo{% endblock %}
+{% block title %}Generate – CrayonAI{% endblock %}
 {% block content %}
   <section class="flex items-center justify-center">
     <div class="card w-full max-w-md text-center">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,11 +1,18 @@
 {% extends "base.html" %}
-{% block title %}Home – Draw → Photo{% endblock %}
+{% block title %}Home – CrayonAI{% endblock %}
 {% block content %}
   <section class="flex items-center justify-center h-[60vh]">
     <div class="card text-center">
-      <h1 class="text-4xl font-bold mb-4">Draw &rarr; Photo</h1>
+      <h1 class="text-4xl font-bold mb-4">CrayonAI</h1>
       <p class="mb-6">Turn your sketches into stunning photos using AI.</p>
       <a href="{{ '/generate' if user else '/login' }}" class="btn-primary">Get Started</a>
     </div>
+  </section>
+
+  <section class="relative bg-white">
+    <svg class="absolute -top-24 left-0 w-full h-24" viewBox="0 0 1440 320" preserveAspectRatio="none">
+      <path fill="#ffffff" d="M0,160 Q720,0 1440,160 L1440,320 L0,320 Z"></path>
+    </svg>
+    <div class="py-16"></div>
   </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Rebrand site from Draw → Photo to CrayonAI, updating titles, nav, and footer
- Add animated multicolor gradient background and curved white section beneath hero

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689288636e38833091c243ec1e46fc0b